### PR TITLE
Add submit button to the top of the page

### DIFF
--- a/files/inc/plugins/goodbyespammer.php
+++ b/files/inc/plugins/goodbyespammer.php
@@ -128,7 +128,10 @@ delete=Delete",
 <input type=\"hidden\" name=\"action\" value=\"do_goodbyespammer\" />
 <table border=\"0\" cellspacing=\"{\$theme['borderwidth']}\" cellpadding=\"{\$theme['tablespace']}\" class=\"tborder\">
 <tr>
-<td class=\"thead\" colspan=\"2\"><strong>{\$lang->goodbyespammer_actionstotake}</strong></td>
+<td class=\"thead\" colspan=\"2\">
+<strong>{\$lang->goodbyespammer_actionstotake}</strong>
+<input type=\"submit\" value=\"{\$lang->goodbyespammer_submit}\" class=\"float_right\" />
+</td>
 </tr>
 <tr>
 <td class=\"tcat\" colspan=\"2\">{\$lang->goodbyespammer_desc}</td>


### PR DESCRIPTION
[As suggested](http://community.mybb.com/thread-145998-post-1049296.html#pid1049296) I'm adding a submit button at the top of the Goodbye Spammer page to avoid scrolling when really you just want to delete that spammer as soon as possible. It looks like this:

![goodbyespammer_actions](https://f.cloud.github.com/assets/180382/1608716/3eafa08a-5511-11e3-95b8-387c0e186986.png)

If you merge, note that I didn't update versions or tags. I wasn't sure if you wanted to go to v1.2 or v1.1.2. I also didn't update the screenshot because I don't have OSX and it wouldn't match (OCD much?). I'll let you do all that afterwards. I can do it too if you want. :P

Or don't merge at all and implement the button differently.
